### PR TITLE
Add additional vgmsite domains to url.txt

### DIFF
--- a/config_sample/url.txt
+++ b/config_sample/url.txt
@@ -4,4 +4,5 @@ https://vgmsite.com/
 https://fi.zophar.net/
 https://litter.catbox.moe/
 https://dl.vgmdownloads.com/
-
+https://epsilon.vgmsite.com/
+https://vgmtreasurechest.com/


### PR DESCRIPTION
Allows more vgmsite domains to be used if their direct links do not come from vgmsite.com or dl.vgmdownloads.com